### PR TITLE
Revert RAG book to $0.99 launch pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&click=book-buy-amazon-image&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-atp-20&text=Best%20Seller%20Image"><img src="images/rag_book_best_seller.png" alt="#1 Best Seller in Generative AI on Amazon - Click to buy" width="500"></a>
 
 **[RAG Made Simple](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&click=book-buy-amazon-title&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-atp-20&text=RAG%20Made%20Simple)** — **#1 Best Seller on Amazon in Generative AI.**
-22 RAG techniques with intuition, comparisons, and illustrations. **Free with Kindle Unlimited** or **$9.99** on Amazon.
+22 RAG techniques with intuition, comparisons, and illustrations. **Free with Kindle Unlimited** or **$0.99** launch price (goes up soon).
 
 ### 👉 [**Get the book on Amazon**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&click=book-buy-amazon-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-atp-20&text=Get%20the%20book%20on%20Amazon)
 


### PR DESCRIPTION
Reverts the RAG Made Simple promotion to launch pricing ($0.99).

The book was briefly raised to $9.99 on Apr 13 to prep for a Kindle
Countdown Deal, but that triggered KDP's 30-day list price stability
rule which blocked the countdown. The price has been restored to
$0.99 for the rest of the launch window; the book will move to steady
state pricing at a later date.

PE Book countdown remains active at $2.99 through April 21 (PE Book
was eligible because it's been at $9.99 for over a year).

No structural changes to the README. Only the pricing copy is
reverted to match the original launch message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "RAG Made Simple" book launch pricing from $9.99 to $0.99 with a temporary pricing notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->