### PR TITLE
docs: add MCP tutorial server script

### DIFF
--- a/tutorials/agent-with-mcp/scripts/mcp_server.py
+++ b/tutorials/agent-with-mcp/scripts/mcp_server.py
@@ -4,6 +4,8 @@ The server exposes a CoinGecko-backed tool that Claude Desktop or another MCP
 client can call to look up the current price of a cryptocurrency.
 """
 
+import json
+
 import httpx
 from mcp.server.fastmcp import FastMCP
 
@@ -20,7 +22,11 @@ async def get_crypto_price(crypto_id: str, currency: str = "usd") -> str:
         crypto_id: CoinGecko cryptocurrency ID, such as "bitcoin" or "ethereum".
         currency: Fiat or crypto quote currency, such as "usd".
     """
-    params = {"ids": crypto_id, "vs_currencies": currency}
+    normalized_crypto_id = crypto_id.strip().lower()
+    normalized_currency = currency.strip().lower()
+    params = {"ids": normalized_crypto_id, "vs_currencies": normalized_currency}
+
+    response: httpx.Response | None = None
 
     try:
         async with httpx.AsyncClient() as client:
@@ -32,14 +38,25 @@ async def get_crypto_price(crypto_id: str, currency: str = "usd") -> str:
             response.raise_for_status()
 
         data = response.json()
-        if crypto_id not in data or currency not in data[crypto_id]:
+        if (
+            normalized_crypto_id not in data
+            or normalized_currency not in data[normalized_crypto_id]
+        ):
             return (
                 f"No price found for '{crypto_id}' in '{currency}'. "
                 "Please check the CoinGecko ID and currency."
             )
 
-        price = data[crypto_id][currency]
-        return f"The current price of {crypto_id} is {price} {currency.upper()}."
+        price = data[normalized_crypto_id][normalized_currency]
+        return f"The current price of {normalized_crypto_id} is {price} {normalized_currency.upper()}."
+    except json.JSONDecodeError:
+        if response is None:
+            return "CoinGecko returned non-JSON data before a response was available."
+        snippet = response.text[:200]
+        return (
+            f"CoinGecko returned non-JSON data with status {response.status_code}: "
+            f"{snippet}"
+        )
     except httpx.HTTPStatusError as exc:
         return f"CoinGecko API error: {exc.response.status_code} - {exc.response.text}"
     except httpx.HTTPError as exc:

--- a/tutorials/agent-with-mcp/scripts/mcp_server.py
+++ b/tutorials/agent-with-mcp/scripts/mcp_server.py
@@ -1,0 +1,50 @@
+"""Minimal MCP server used by the agent-with-mcp tutorial.
+
+The server exposes a CoinGecko-backed tool that Claude Desktop or another MCP
+client can call to look up the current price of a cryptocurrency.
+"""
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+COINGECKO_BASE_URL = "https://api.coingecko.com/api/v3"
+
+mcp = FastMCP("crypto_price_tracker")
+
+
+@mcp.tool()
+async def get_crypto_price(crypto_id: str, currency: str = "usd") -> str:
+    """Return the current price for a cryptocurrency.
+
+    Args:
+        crypto_id: CoinGecko cryptocurrency ID, such as "bitcoin" or "ethereum".
+        currency: Fiat or crypto quote currency, such as "usd".
+    """
+    params = {"ids": crypto_id, "vs_currencies": currency}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{COINGECKO_BASE_URL}/simple/price",
+                params=params,
+                timeout=10,
+            )
+            response.raise_for_status()
+
+        data = response.json()
+        if crypto_id not in data or currency not in data[crypto_id]:
+            return (
+                f"No price found for '{crypto_id}' in '{currency}'. "
+                "Please check the CoinGecko ID and currency."
+            )
+
+        price = data[crypto_id][currency]
+        return f"The current price of {crypto_id} is {price} {currency.upper()}."
+    except httpx.HTTPStatusError as exc:
+        return f"CoinGecko API error: {exc.response.status_code} - {exc.response.text}"
+    except httpx.HTTPError as exc:
+        return f"Error fetching price data: {exc}"
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tutorials/agent-with-mcp/scripts/mcp_server.py
+++ b/tutorials/agent-with-mcp/scripts/mcp_server.py
@@ -38,16 +38,17 @@ async def get_crypto_price(crypto_id: str, currency: str = "usd") -> str:
             response.raise_for_status()
 
         data = response.json()
-        if (
-            normalized_crypto_id not in data
-            or normalized_currency not in data[normalized_crypto_id]
-        ):
+        if not isinstance(data, dict):
+            return "CoinGecko returned an unexpected response format."
+
+        coin_data = data.get(normalized_crypto_id)
+        if not isinstance(coin_data, dict) or normalized_currency not in coin_data:
             return (
                 f"No price found for '{crypto_id}' in '{currency}'. "
                 "Please check the CoinGecko ID and currency."
             )
 
-        price = data[normalized_crypto_id][normalized_currency]
+        price = coin_data[normalized_currency]
         return f"The current price of {normalized_crypto_id} is {price} {normalized_currency.upper()}."
     except json.JSONDecodeError:
         if response is None:


### PR DESCRIPTION
## Summary
- Add the missing `tutorials/agent-with-mcp/scripts/mcp_server.py` referenced by the MCP tutorial notebook.
- Provide a minimal FastMCP CoinGecko price tool so the documented copy/run steps have a real script to use.

## Validation
- `git diff --check`
- `python3 -m py_compile tutorials/agent-with-mcp/scripts/mcp_server.py`
- Targeted check confirmed the notebook references `scripts/mcp_server.py` and the file now exists.

## Confidence
- 90/100 — examples/docs support category. The open issue identifies the exact missing path, there is no duplicate open PR, and the patch adds the referenced tutorial script with a focused compile check.

Fixes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a minimal cryptocurrency price-tracking MCP server for the tutorial that fetches CoinGecko prices and returns formatted price results for a requested coin and currency.
* **Bug Fixes / Reliability**
  * Improved error handling for timeouts, non-JSON or malformed responses, and HTTP errors to produce clear user-facing messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NirDiamant/agents-towards-production/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->