### PR TITLE
fix: declare PyPDF2 for the Streamlit tutorial

### DIFF
--- a/tutorials/agent-with-streamlit-ui/requirements.txt
+++ b/tutorials/agent-with-streamlit-ui/requirements.txt
@@ -1,4 +1,5 @@
 streamlit>=1.28.0
 langchain>=0.1.0
 openai>=1.0.0
-python-dotenv>=1.0.0 
+python-dotenv>=1.0.0
+PyPDF2>=3.0.1


### PR DESCRIPTION
## Summary

- add the missing `PyPDF2` dependency used by the Streamlit tutorial app
- normalize the existing requirements file ending

## Motivation

`tutorials/agent-with-streamlit-ui/app.py` imports `PyPDF2` to process uploaded PDF files, but the tutorial's `requirements.txt` does not install it. A clean installation therefore fails with `ModuleNotFoundError: No module named 'PyPDF2'` before the app can start.

## Validation

- reproduced the missing import in a clean uv virtual environment using the original requirements file
- `uv pip install --python .venv/bin/python -r tutorials/agent-with-streamlit-ui/requirements.txt`
- `.venv/bin/python -c 'import PyPDF2; assert PyPDF2.__version__ == "3.0.1"'`
- `git diff --check origin/main...HEAD`

## Pre-PR checklist

- [x] Change is limited to the existing tutorial dependency list
- [x] Dependency is explicitly version-bounded
- [x] No API keys or sensitive information added
- [x] Clean-environment import verified
- [x] No unrelated tutorial content changed

## Risks / known gaps

This PR only fixes dependency installation. It does not change the Streamlit application or execute live OpenAI requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF processing support to the Streamlit tutorial.

* **Chores**
  * Cleaned up dependency formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->