### PR TITLE
fix: declare pandas for the agent security tutorial

### DIFF
--- a/tutorials/agent-security-apex/requirements.txt
+++ b/tutorials/agent-security-apex/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv>=1.0.0
 aiohttp>=3.8.0
 ipython>=7.30.1
 openai>=1.0.0
+pandas>=2.0.0


### PR DESCRIPTION
## Summary

- add the missing `pandas` dependency to the agent security tutorial requirements
- normalize the existing requirements file ending

## Motivation

The tutorial's testing framework imports `pandas` in `model_testing_tools.py`, and the README includes pandas in its quick-start command. However, `requirements.txt` omits it, so a clean requirements installation cannot import the tutorial code.

## Validation

- reproduced the missing import in a clean uv virtual environment using the original requirements file
- `uv pip install --python .venv/bin/python -r tutorials/agent-security-apex/requirements.txt`
- `.venv/bin/python -c 'import pandas; print(pandas.__version__)'` (3.0.5)
- `git diff --check origin/main...HEAD`

## Pre-PR checklist

- [x] Change is limited to the existing tutorial dependency list
- [x] Dependency has a compatible lower bound
- [x] No API keys or sensitive information added
- [x] Clean-environment import verified
- [x] No unrelated security tutorial behavior changed

## Risks / known gaps

This PR verifies dependency installation only. It does not run the live OpenAI-backed security evaluation, which requires credentials and incurs external API calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the tutorial’s Python dependencies to include pandas 2.0 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->