### PR TITLE
test: fix FastAPI streaming response assertions

### DIFF
--- a/tutorials/fastapi-agent/tests/test_fastapi_agent.py
+++ b/tutorials/fastapi-agent/tests/test_fastapi_agent.py
@@ -33,7 +33,6 @@ def test_stream_endpoint():
     """Test the streaming agent endpoint"""
     with client.stream("POST", "/agent/stream", json={"query": "Test query"}) as response:
         assert response.status_code == 200
-        assert response.headers["content-type"] == "text/event-stream"
-        # Check that we receive at least some content
-        content = response.iter_content().read()
-        assert len(content) > 0 
+        assert response.headers["content-type"].startswith("text/event-stream")
+        content = "".join(response.iter_text())
+        assert 'data: {"token":' in content


### PR DESCRIPTION
## Summary

- accept the optional charset parameter in the SSE content type
- consume the TestClient response through the supported `iter_text()` API
- assert that the endpoint emits an actual SSE data frame

## Motivation

The streaming test currently expects an exact `text/event-stream` header, while FastAPI may append `charset=utf-8`. It also calls `iter_content()`, which is a requests API and is not available on the httpx response returned by FastAPI's TestClient. These assertions prevent the tutorial test suite from validating the streaming endpoint.

## Validation

- reproduced the existing failure against FastAPI 0.141.1 and httpx 0.28.1
- `.venv/bin/python -m pytest tutorials/fastapi-agent/tests/test_fastapi_agent.py -q`
  - result: 3 passed
- `git diff --check origin/main...HEAD`

## Pre-PR checklist

- [x] Change is limited to the existing FastAPI streaming test
- [x] Test exercises the real FastAPI endpoint
- [x] SSE content is validated rather than only checking for non-empty bytes
- [x] No API keys or external services required
- [x] No production behavior changed

## Risks / known gaps

The suite still reports existing Starlette and Pydantic deprecation warnings. Updating those APIs is intentionally outside this focused test fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved streaming endpoint validation to support content type variants.
  - Added verification that streamed responses contain properly formatted server-sent events.
  - Updated response handling to read streamed text directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->