### PR TITLE
README: feature the new while-loop agents film in the video rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,22 +310,31 @@ _Join over 50,000 AI enthusiasts getting unique cutting-edge insights and free t
 
 <table>
 <tr>
-<td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&amp;click=youtube-readme-ctx&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&amp;retarget=0&amp;text=youtube-readme-ctx">
+<td width="50%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&amp;click=youtube-readme-loop&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DFN1n_NVD9KM%26list%3DPLBrpE2PttR2k&amp;retarget=0&amp;text=youtube-readme-loop">
+    <img src="https://img.youtube.com/vi/FN1n_NVD9KM/mqdefault.jpg" width="100%" alt="">
+    <br><b>AI Agents Are Just While Loops. That's the Scary Part.</b>
+  </a><br>
+  <sub>the whole agent is a text file re-read in a loop, and it can trap itself</sub>
+</td>
+<td width="50%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&amp;click=youtube-readme-ctx&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng%26list%3DPLBrpE2PttR2k&amp;retarget=0&amp;text=youtube-readme-ctx">
     <img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="">
     <br><b>Context Is the New Code</b>
   </a><br>
   <sub>the shift from writing the code to shaping what the model sees</sub>
 </td>
-<td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&amp;click=youtube-readme-cc&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&amp;retarget=0&amp;text=youtube-readme-cc">
+</tr>
+<tr>
+<td width="50%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&amp;click=youtube-readme-cc&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc%26list%3DPLBrpE2PttR2k&amp;retarget=0&amp;text=youtube-readme-cc">
     <img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="">
     <br><b>Stop Thinking Claude Code Is Magic. Here's How It Works</b>
   </a><br>
   <sub>what the agent loop is actually doing on every turn</sub>
 </td>
-<td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&amp;click=youtube-readme-llm&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&amp;retarget=0&amp;text=youtube-readme-llm">
+<td width="50%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agents-towards-production--readme&amp;click=youtube-readme-llm&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc%26list%3DPLBrpE2PttR2k&amp;retarget=0&amp;text=youtube-readme-llm">
     <img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="">
     <br><b>How LLMs Actually Work (and Why AI Makes Things Up)</b>
   </a><br>


### PR DESCRIPTION
Adds the new film (AI Agents Are Just While Loops. That's the Scary Part.) as the lead tile of the Prefer video? rail and reshapes it to a 2x2 grid. All four tiles now carry the `&list=` playlist deep link (the three existing tiles were bare watch URLs). Links stay on the click tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new video about AI agents and while loops.
  * Updated the video table to use two equal-width columns across two rows.
* **Documentation**
  * Updated existing video links with playlist-aware tracking URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->